### PR TITLE
Update `Dockerfile` in order to build the container image without the local `node_modules/`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ FROM alpine:3.17.1
 # Install nodejs
 RUN apk add --no-cache nodejs npm
 
+COPY package*.json ./
+RUN npm install --only=prod
+
 COPY index.js index.js
-COPY node_modules/ node_modules/
 
 # Expose port 3000
 EXPOSE 3000


### PR DESCRIPTION
Update `Dockerfile` in order to build the container image without the local `node_modules/`.

Otherwise, getting this error while running `docker build`:
```
=> ERROR [4/4] COPY node_modules/ node_modules/
```