### PR TITLE
Add github action to build and push a docker image

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -2,7 +2,7 @@ name: Publish docker image
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
 
 env:
   REGISTRY: registry.humanitec.io/public

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -1,0 +1,27 @@
+name: Publish docker image
+
+on:
+  push:
+    branches: ['master']
+
+env:
+  REGISTRY: registry.humanitec.io/public
+  IMAGE_NAME: sample-score-app
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build and push Docker image
+        uses: mr-smithers-excellent/docker-build-push@v6
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+          tags: latest
+          


### PR DESCRIPTION
This is adding a GitHub Action to build and push a docker image once a push to main happened. Registry credentials have been added as action secrets.