### PR TITLE
`.devcontainer`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
-	"name": "score-compose",
+	"name": "Score Dev Container",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/base:jammy",
 	"features": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,11 +23,11 @@
 			"extensions": [
 				"redhat.vscode-yaml"
 			],
-            "settings": {
-                "yaml.schemas": {
+			"settings": {
+				"yaml.schemas": {
 					"https://raw.githubusercontent.com/score-spec/schema/main/score-v1b1.json": "score.yaml"
-				  }
-            }
+				}
+			}
 		}
-	  }
+	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,5 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
 	"name": "Score Dev Container",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/base:jammy",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "score-compose",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"moby": true,
+			"installDockerComposeSwitch": true,
+			"version": "latest",
+			"dockerDashComposeVersion": "latest"
+		},
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+			"version": "latest",
+			"helm": "latest",
+			"minikube": "latest"
+		}
+	},
+	"postCreateCommand": "bash .devcontainer/installMoreTools.sh",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"redhat.vscode-yaml"
+			],
+            "settings": {
+                "yaml.schemas": {
+					"https://raw.githubusercontent.com/score-spec/schema/main/score-v1b1.json": "score.yaml"
+				  }
+            }
+		}
+	  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,9 +7,7 @@
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"moby": true,
-			"installDockerComposeSwitch": true,
-			"version": "latest",
-			"dockerDashComposeVersion": "latest"
+			"version": "latest"
 		},
 		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
 			"version": "latest",

--- a/.devcontainer/installMoreTools.sh
+++ b/.devcontainer/installMoreTools.sh
@@ -13,12 +13,12 @@ SCORE_HELM_VERSION=$(curl -sL https://api.github.com/repos/score-spec/score-helm
 wget https://github.com/score-spec/score-helm/releases/download/${SCORE_HELM_VERSION}/score-helm_${SCORE_HELM_VERSION}_linux_amd64.tar.gz
 tar -xvf score-helm_${SCORE_HELM_VERSION}_linux_amd64.tar.gz
 chmod +x score-helm
-mv score-helm /usr/local/bin
+sudo mv score-helm /usr/local/bin
 
 KIND_VERSION=$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r .tag_name)
 curl -Lo ./kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
 chmod +x ./kind
-mv ./kind /usr/local/bin/kind
+sudo mv ./kind /usr/local/bin/kind
 
 cd ..
 rm -rf install-more-tools

--- a/.devcontainer/installMoreTools.sh
+++ b/.devcontainer/installMoreTools.sh
@@ -6,19 +6,19 @@ cd install-more-tools
 SCORE_COMPOSE_VERSION=$(curl -sL https://api.github.com/repos/score-spec/score-compose/releases/latest | jq -r .tag_name)
 wget https://github.com/score-spec/score-compose/releases/download/${SCORE_COMPOSE_VERSION}/score-compose_${SCORE_COMPOSE_VERSION}_linux_amd64.tar.gz
 tar -xvf score-compose_${SCORE_COMPOSE_VERSION}_linux_amd64.tar.gz
-sudo chmod +x score-compose
+chmod +x score-compose
 sudo mv score-compose /usr/local/bin
 
 SCORE_HELM_VERSION=$(curl -sL https://api.github.com/repos/score-spec/score-helm/releases/latest | jq -r .tag_name)
 wget https://github.com/score-spec/score-helm/releases/download/${SCORE_HELM_VERSION}/score-helm_${SCORE_HELM_VERSION}_linux_amd64.tar.gz
 tar -xvf score-helm_${SCORE_HELM_VERSION}_linux_amd64.tar.gz
-sudo chmod +x score-helm
-sudo mv score-helm /usr/local/bin
+chmod +x score-helm
+mv score-helm /usr/local/bin
 
 KIND_VERSION=$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r .tag_name)
 curl -Lo ./kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
 chmod +x ./kind
-sudo mv ./kind /usr/local/bin/kind
+mv ./kind /usr/local/bin/kind
 
 cd ..
 rm -rf install-more-tools

--- a/.devcontainer/installMoreTools.sh
+++ b/.devcontainer/installMoreTools.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+mkdir install-more-tools
+cd install-more-tools
+
+SCORE_COMPOSE_VERSION=$(curl -sL https://api.github.com/repos/score-spec/score-compose/releases/latest | jq -r .tag_name)
+wget https://github.com/score-spec/score-compose/releases/download/${SCORE_COMPOSE_VERSION}/score-compose_${SCORE_COMPOSE_VERSION}_linux_amd64.tar.gz
+tar -xvf score-compose_${SCORE_COMPOSE_VERSION}_linux_amd64.tar.gz
+sudo chmod +x score-compose
+sudo mv score-compose /usr/local/bin
+
+SCORE_HELM_VERSION=$(curl -sL https://api.github.com/repos/score-spec/score-helm/releases/latest | jq -r .tag_name)
+wget https://github.com/score-spec/score-helm/releases/download/${SCORE_HELM_VERSION}/score-helm_${SCORE_HELM_VERSION}_linux_amd64.tar.gz
+tar -xvf score-helm_${SCORE_HELM_VERSION}_linux_amd64.tar.gz
+sudo chmod +x score-helm
+sudo mv score-helm /usr/local/bin
+
+KIND_VERSION=$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r .tag_name)
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
+chmod +x ./kind
+sudo mv ./kind /usr/local/bin/kind
+
+cd ..
+rm -rf install-more-tools

--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -20,12 +20,6 @@ jobs:
           file: score-compose
           token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ env.SCORE_COMPOSE_VERSION }}
-      - name: make compose.yaml
-        run: |
-          make compose.yaml
-      - name: make compose-up
-        run: |
-          make compose-up
       - name: make compose-test
         run: |
           make compose-test

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a simple micro service which is deployed with Score (`score-compose` and
 
 ## The Workload
 
-The workload is a simple containerized NodeJS app which talking to a PostreSQL database.
+The workload is a simple containerized NodeJS app talking to a PostreSQL database.
 
 ## Deploying
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a simple micro service which is deployed with Score (`score-compose` and `score-helm`).
 
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/score-spec/sample-score-app)
+
 ## The Workload
 
 The workload is a simple containerized NodeJS app which talking to a PostreSQL database.


### PR DESCRIPTION
Add a devcontainer config with pre-installed tools:
- `docker` and `docker compose`
- `kubectl`
- `helm`
- `minikube`
- `kind`
- `score-compose`
- `score-helm`

This will avoid the manual installation of:
- `score-compose`
- `score-helm`

Also, add the IDE linter for Score's JSON schema: https://docs.score.dev/docs/score-specification/ide-linter-autocomplete/

When opening this repo locally with VS Code, users will have this popup in order to get the benefice of this devcontainer:
<img width="333" alt="image" src="https://github.com/score-spec/sample-score-app/assets/11720844/b5871611-6b23-4d6a-b0db-6726d924a84d">

Same approach with GitHub Codespace.


Notes: nothing related but also took the initiative to:
- Fix a typo in README
- Simplify `compose-test` call in `Makefile`