### PR TITLE
Multi stage build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM alpine:3.19.1
-
-# Install nodejs
+FROM alpine:3.19.1 as builder
 RUN apk add --no-cache nodejs npm
-
 COPY package*.json ./
 RUN npm install --only=prod
 
+FROM alpine:3.19.1
+RUN apk add --no-cache nodejs
+COPY --from=builder /node_modules ./node_modules
 COPY index.js index.js
-
-# Expose port 3000
 EXPOSE 3000
-
-# Run the app
 CMD ["node", "index.js"]


### PR DESCRIPTION
Reduce the container size image from 71.3MB (280 packages!) to 63.7MB (44 packages!) ==> -7.6MB (-236 packages).

Note: still keeping `alpine` as I tried with `distroless` but the size was 174MB... not intended for the purpose of this PR.