### PR TITLE
With `score-k8s`, no need of `.env` anymore

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-DB_HOST=localhost
-DB_NAME=database
-DB_PASSWORD=super-password
-DB_PORT=5432
-DB_USERNAME=postgres

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,6 @@ help:
 .PHONY: .FORCE
 .FORCE:
 
-include .env
-
 CONTAINER_NAME = hello-world
 CONTAINER_IMAGE = ${CONTAINER_NAME}:test
 WORKLOAD_NAME = hello-world

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,11 @@ CONTAINER_NAME = hello-world
 CONTAINER_IMAGE = ${CONTAINER_NAME}:test
 WORKLOAD_NAME = hello-world
 
-compose.yaml: score.yaml
+.score-compose/state.yaml:
 	score-compose init \
 		--no-sample
+
+compose.yaml: score.yaml .score-compose/state.yaml Makefile
 	score-compose generate score.yaml \
 		--build '${CONTAINER_NAME}={"context":".","tags":["${CONTAINER_IMAGE}"]}' \
 		--override-property containers.${CONTAINER_NAME}.variables.MESSAGE="Hello, Compose!"


### PR DESCRIPTION
Small cleanup, with `score-k8s`, no need of `.env` anymore