### PR TITLE
Update devcontainer.json - Fix broken link for schema

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
 			],
 			"settings": {
 				"yaml.schemas": {
-					"https://raw.githubusercontent.com/score-spec/schema/main/score-v1b1.json": "score.yaml"
+					"https://raw.githubusercontent.com/score-spec/spec/main/score-v1b1.json": "score.yaml"
 				}
 			}
 		}


### PR DESCRIPTION
Related to this: https://github.com/score-spec/docs/pull/117, otherwise 404 in VS Code:
```
Unable to load schema from 'https://raw.githubusercontent.com/score-spec/schema/main/score-v1b1.json': Request vscode/content failed unexpectedly without providing any details.
```