### PR TITLE
devcontainer - noble + latest moby

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,10 @@
 {
 	"name": "Score Dev Container",
-	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"image": "mcr.microsoft.com/devcontainers/base:noble",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"moby": true,
-			"_comment": "cannot use latest for now because of this current issue: https://github.com/kubernetes-sigs/kind/issues/3696",
-			"version": "26.1.4" 
+			"version": "latest" 
 		},
 		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
 			"version": "latest",


### PR DESCRIPTION
`devcontainer`:
- `mcr.microsoft.com/devcontainers/base:jammy` (Ubuntu 22) --> `mcr.microsoft.com/devcontainers/base:noble` (Ubuntu 24)
- `latest` `moby` with `ghcr.io/devcontainers/features/docker-in-docker:2`

Tested:
```bash
make compose-up
make compose-test

make kind-create-cluster
make kind-load-image
make k8s-up
make k8s-test
```