### PR TITLE
Fix podman devcontainer.json

### DIFF
--- a/.devcontainer/podman/Dockerfile
+++ b/.devcontainer/podman/Dockerfile
@@ -1,2 +1,7 @@
 FROM mcr.microsoft.com/devcontainers/base:noble
-RUN sudo apt update && sudo apt -y install podman
+ARG TARGETPLATFORM
+ARG PODMAN_VERSION="v5.5.1"
+ARG PODMAN_URL="https://github.com/containers/podman/releases/download/${PODMAN_VERSION}"
+RUN curl -sSL ${PODMAN_URL}/podman-remote-static-linux_${TARGETPLATFORM##*/}.tar.gz | tar xz -C /usr/local/ bin/podman-remote-static-linux_${TARGETPLATFORM##*/} && \
+    chmod +x /usr/local/bin/podman-remote-static-linux_${TARGETPLATFORM##*/} && \
+    ln -s /usr/local/bin/podman-remote-static-linux_${TARGETPLATFORM##*/} /usr/local/bin/podman

--- a/.devcontainer/podman/devcontainer.json
+++ b/.devcontainer/podman/devcontainer.json
@@ -1,19 +1,20 @@
 {
 	"name": "Score Dev Container with Podman",
 	"build": {
-        "dockerfile": "Dockerfile"
+		"dockerfile": "Dockerfile",
+		"args": {
+			"PODMAN_VERSION": "v5.5.1"
+		}
     },
 	"features": {
+			"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+				"version": "latest",
+				"dockerDashComposeVersion": "none"
+			}
 	},
-	//"remoteEnv": {
-    //    "PODMAN_USERNS": "keep-id"
-    //  },
-    //"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,Z",
-    //"workspaceFolder": "/workspace",
-    //"runArgs": ["--userns=keep-id"],
-    "containerUser": "vscode",
-    "containerEnv": {
-      "HOME": "/home/vscode"
+	"remoteUser": "root",
+	"remoteEnv": {
+		"CONTAINER_HOST": "unix:///var/run/docker.sock"
     },
 	"postCreateCommand": "bash .devcontainer/installMoreTools.sh",
 	"customizations": {


### PR DESCRIPTION
With these changes I was able to start the Podman devcontainer with VS Code on my macOS (podman must be installed locally and up and running `podman machine init --now`) and use Podman from the terminal:

<img width="690" alt="image" src="https://github.com/user-attachments/assets/50278bfc-e50b-4887-ac9d-50b24b03f4b2" />

Unfortunately, when trying that on GitHub Codespaces, the podman client isn't able to communicate with the Docker service that is running on the host:

<img width="774" alt="image" src="https://github.com/user-attachments/assets/deaaa17e-ffd4-4ced-8beb-da5fb88915f6" />
