### PR TITLE
Enable manual trigger only for release

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -1,8 +1,7 @@
 name: Create and publish a Docker image
 
 on:
-  push:
-    branches: ['main']
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Change trigger to allow manual workflow dispatch.

Otherwise, the previous continuous deployment as soon as a commit is merged is not working anymore for security reason by GitHub:
> GitHub's design: When a workflow uses GITHUB_TOKEN to trigger events (like merging a PR → push to main), GitHub intentionally does not trigger other workflows from that resulting event. This is a deliberate security measure to prevent recursive/infinite workflow loops.

And also, this makes sense to manually trigger a release time to time instead of at any commit/PR merged into `main`. We are still publishing only `latest` tag though, no change here (no need to track version for this sample app).