### PR TITLE
Update build base image to -sfw

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM dhi.io/node:26-alpine3.24-sfw-dev AS builder
 WORKDIR /usr/src/app
 COPY package*.json ./
-RUN npm install --only=prod
+RUN npm i --omit=dev
 
 FROM dhi.io/node:26-alpine3.24
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dhi.io/node:26-alpine3.24-dev AS builder
+FROM dhi.io/node:26-alpine3.24-sfw-dev AS builder
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm install --only=prod


### PR DESCRIPTION
Use the `-sfw` for the build stage.

Also, removed this warning:
```none
npm warn config only Use `--omit=dev` to omit dev dependencies from the install.
```